### PR TITLE
Fix typo: Change "MtSQL" to "MySQL" in project works

### DIFF
--- a/index.html
+++ b/index.html
@@ -207,7 +207,7 @@
                           <li class="is-size-6 px-1 text-light">
                             Spring Security
                           </li>
-                          <li class="is-size-6 pl-2 text-light">MtSQL</li>
+                          <li class="is-size-6 pl-2 text-light">MySQL</li>
                         </ul>
                       </footer>
                     </div>


### PR DESCRIPTION
- Corrected the typo "MtSQL" to "MySQL" in the content of project work cards.
- Ensures accurate representation of technologies used in the project.
